### PR TITLE
Update regexp for target rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class SVGIcon {
         //console.log('loading svgicon');
         Mix.listen('configReady', function (config) {  
             const rules = config.module.rules;
-            const targetRegex = /(\.(png|jpe?g|gif)$|^((?!font).)*\.svg$)/;
+            const targetRegex = /(\.(png|jpe?g|gif|webp)$|^((?!font).)*\.svg$)/;
             
             for (let rule of rules) {
                 if (rule.test.toString() == targetRegex.toString()) {


### PR DESCRIPTION
Fixes issue where loader rule isn't replaced for SVGs (causing file-loader to be used instead of html-loader) and plugin only outputting filename instead of actual SVG code.

Fixes #1